### PR TITLE
added pi route api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '0.10'
+- '6'
 deploy:
   provider: heroku
   api_key:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,9 @@
+Docker Setup
+============
+
+Install Docker for Mac: https://www.docker.com/products/overview
+
+* `make` to build the base container (make each time you change the app)
+* `make run` to start it http://127.0.0.1:3000
+* `docker-compose up` start both the mongo and site containers for API testing
+* `docker-compose build app` to build the app container for compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM nodesource/xenial
+
+ENV PORT=3000
+
+RUN mkdir /hacksi
+WORKDIR /hacksi
+
+COPY ./ /hacksi/
+RUN cd /hacksi && npm install
+
+ENTRYPOINT cd /hacksi && node ./app.js
+EXPOSE 3000

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+build:
+	docker build . -t hacksi
+
+run:
+	docker run --rm -it -p 3000:3000 hacksi
+
+debug:
+	docker run --rm -it -p 3000:3000 --entrypoint /bin/bash hacksi
+
+all: build
+
+.PHONY: all build run debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+    app:
+        build: .
+        environment: 
+            - MONGOLAB_URI=mongodb://mongodb/hacksi
+        ports:
+            - "3000:3000"
+        depends_on:
+            - mongodb
+    mongodb:
+        environment:
+            - AUTH=no
+        image: tutum/mongodb:3.2
+        ports:
+            - "27017:27017"

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,41 @@
+var mongo = require('mongodb');
+var joi = require('joi');
+/*
+ * We open and close this per request since we don't know how long between requests we will have.
+ */
+
+exports.validate = {
+    payload: {
+        host: joi.string().min(4).required(),
+        ip: joi.string().ip({
+            version: ['ipv4'],
+            cidr: 'forbidden'
+        })
+    }
+};
+
+exports.post = function(req, res) {
+    var pi = {
+        _id: req.payload.host,
+        host: req.payload.host,
+        ip: req.payload.ip,
+        stamp: Date.now(),
+        from: req.headers['x-forwarded-for'] || req.info.remoteAddress
+    };
+    mongo.connect(process.env.MONGOLAB_URI, function(err, db) {
+        db.collection('pis').update({ _id: pi._id }, pi, { upsert: true }, function(err) {
+            if (err) {
+                console.log(err);
+            }
+            db.close();
+            res(pi);
+        });
+    });
+};
+
+exports.get = function(req, res) {
+    mongo.connect(process.env.MONGOLAB_URI, function(err, db) {
+        db.collection('pis').find({ $query: {}, $orderby: { host: 1 }}).toArray(res);
+        db.close();
+    });
+};

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -229,5 +229,18 @@ module.exports = [
         handler: function (req, res) {
             res('pDgBc5MrDuMqbg62mufheKjjrgOqc1NMemRDgmAkuD0.IEmiz9fyhGlb2DVtkj-3U3PXjdYfB3rvnyzPNopUCh4');
         }
+    },
+    {
+        method: "POST",
+        path: "/api/pi",
+        handler: require('./api').post,
+        config: {
+            validate: require('./api').validate
+        }
+    },
+    {
+        method: "GET",
+        path: "/api/pi",
+        handler: require('./api').get
     }
 ]

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "author": "Dav Glass <davglass@gmail.com>",
   "version": "0.0.0",
   "engines": {
-    "node": "0.10.x"
+    "node": "6.x"
   },
   "dependencies": {
     "handlebars": "~3.0.3",
-    "hapi": "~8.8.0"
+    "hapi": "~8.8.0",
+    "joi": "^9.2.0",
+    "mongodb": "^2.2.11"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
This exposes a `GET` and `POST` route at: `/api/pi`

The `GET` will list the contents of the DB, the post accepts: `host` and `ip` parameters.

```
 curl -X POST -d "host=hacksi1&ip=111.111.111.111" http://127.0.0.1:3000/api/pi
 curl -X POST -d "host=hacksi2&ip=111.111.111.112" http://127.0.0.1:3000/api/pi
 curl -X POST -d "host=hacksi3&ip=111.111.111.113" http://127.0.0.1:3000/api/pi
```

Currently the API isn't protected, we can add a check to it later if we need to.

I'll comment inline on the PR. @Mkoopajr care to look over it before I merge it?