### PR TITLE
Fixed news link

### DIFF
--- a/views/data/news.json
+++ b/views/data/news.json
@@ -5,7 +5,7 @@
             "content": "<p>Sep 1, 2017 ... Southern Illinois native Dav Glass, a self-proclaimed geek, made a name for himself in California’s Silicon Valley as a software architect and engineer with Yahoo. When a new position with the search engine giant gave him the opportunity to return to Marion, Ill. and work from home, he jumped at the chance. His relocation, however, presented a problem.</p>"
         },
         {    
-            "title": "<h3><a href=\"https://appdevelopermagazine.com/4604/2016/11/10/Meet-Dav-Glass,-local-hero-hacker-and-Yahoo-Distinguished-Engineer/<Paste>\">AppDeveloper Magazine | Meet Dav Glass, local hero hacker and Yahoo Distinguished Engineer</a></h3>",
+            "title": "<h3><a href=\"https://appdevelopermagazine.com/4604/2016/11/10/Meet-Dav-Glass,-local-hero-hacker-and-Yahoo-Distinguished-Engineer/\">AppDeveloper Magazine | Meet Dav Glass, local hero hacker and Yahoo Distinguished Engineer</a></h3>",
             "content": "<p>Nov 10, 2016 ... We recently had the opportunity to ask Dav a few questions about open source technology, his expertise in Node.js, and the HackSI annual hackathon. </p>"
         },
         {


### PR DESCRIPTION
There was a vim `<Paste>` marker in the link to an article.