### PR TITLE
fixed press page layout

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -180,8 +180,12 @@ module.exports = [
         path: '/press',
         handler: (req, res) => {
             fs.readFile('./views/data/news.json', (err, data) => {
-                var content = JSON.parse(data);
-                res.view('press', content);
+                res.view('press', {
+                    title: 'press',
+                    currentYear: currentYear,
+                    banners: getBanners(),
+                    press: JSON.parse(data).data
+                });
             });
         }
     },

--- a/views/press.handlebars
+++ b/views/press.handlebars
@@ -1,5 +1,5 @@
 <h2>HackSI in the Press</h2>
-{{#each data}}
+{{#each press}}
     <div class="pure-g content-box">
         <div class="pure-u-1-3">
             <div class="bullet"></div>


### PR DESCRIPTION
Layout on the press page was busted as it didn't have the banners, title, year, etc.. This fixes that issue.